### PR TITLE
Depend on cv_bridge instead of opencv

### DIFF
--- a/rotors_gazebo_plugins/package.xml
+++ b/rotors_gazebo_plugins/package.xml
@@ -26,7 +26,7 @@
   <build_depend>octomap_ros</build_depend>
   <build_depend>octomap</build_depend>
   <build_depend>octomap_msgs</build_depend>
-  <build_depend>opencv</build_depend>
+  <build_depend>cv_bridge</build_depend>
   <build_depend>planning_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>cmake_modules</build_depend>
@@ -43,7 +43,7 @@
   <run_depend>octomap_ros</run_depend>
   <run_depend>octomap</run_depend>
   <run_depend>octomap_msgs</run_depend>
-  <run_depend>opencv</run_depend>
+  <run_depend>cv_bridge</run_depend>
   <run_depend>planning_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>glog_catkin</run_depend>


### PR DESCRIPTION
This is because the rosdep key for opencv changed from "opencv" in hydro to "libopencv-dev" in indigo. Without this change, rosdep fails when told to install the dependencies of rotors_gazebo_plugins.

Depending on cv_bridge will pull in the correct one in either case, and is the recommended solution described here: http://wiki.ros.org/indigo/Migration#OpenCV