### PR TITLE
Use mavros_msgs for mavlink interface

### DIFF
--- a/rotors_description/urdf/iris_base.xacro
+++ b/rotors_description/urdf/iris_base.xacro
@@ -12,12 +12,14 @@
     >
   </xacro:controller_plugin_macro>
 
+  <xacro:if value="$(arg enable_mavlink_interface)">
   <!-- Instantiate mavlink telemetry interface. -->
   <xacro:mavlink_interface_macro
     namespace="${namespace}"
     imu_sub_topic="imu"
     >
   </xacro:mavlink_interface_macro>
+  </xacro:if>
 
   <!-- Mount an ADIS16448 IMU. -->
   <xacro:imu_plugin_macro

--- a/rotors_gazebo/launch/iris_empty_world.launch
+++ b/rotors_gazebo/launch/iris_empty_world.launch
@@ -1,6 +1,7 @@
 <launch>
   <arg name="enable_logging" default="false"/>
   <arg name="enable_ground_truth" default="true"/>
+  <arg name="enable_mavlink_interface" default="false"/>
   <arg name="log_file" default="iris"/>
   <arg name="headless" default="false"/>
   <arg name="gui" default="true"/>
@@ -15,6 +16,7 @@
     <arg name="model" value="$(find rotors_description)/urdf/iris_base.xacro" />
     <arg name="enable_logging" value="$(arg enable_logging)" />
     <arg name="enable_ground_truth" value="$(arg enable_ground_truth)" />
+    <arg name="enable_mavlink_interface" value="$(arg enable_mavlink_interface)" />
     <arg name="log_file" value="$(arg log_file)"/>
   </include>
 </launch>

--- a/rotors_gazebo/launch/iris_house_world.launch
+++ b/rotors_gazebo/launch/iris_house_world.launch
@@ -1,5 +1,6 @@
 <launch>
   <arg name="enable_logging" default="false"/>
+  <arg name="enable_mavlink_interface" default="false"/>
   <arg name="enable_ground_truth" default="true"/>
   <arg name="log_file" default="iris"/>
   <arg name="headless" default="false"/>
@@ -16,6 +17,7 @@
     <arg name="model" value="$(find rotors_description)/urdf/iris_base.xacro" />
     <arg name="enable_logging" value="$(arg enable_logging)" />
     <arg name="enable_ground_truth" value="$(arg enable_ground_truth)" />
+    <arg name="enable_mavlink_interface" value="$(arg enable_mavlink_interface)" />
     <arg name="log_file" value="$(arg log_file)"/>
   </include>
 </launch>

--- a/rotors_gazebo/launch/iris_outdoor_world.launch
+++ b/rotors_gazebo/launch/iris_outdoor_world.launch
@@ -1,5 +1,6 @@
 <launch>
   <arg name="enable_logging" default="false"/>
+  <arg name="enable_mavlink_interface" default="false"/>
   <arg name="enable_ground_truth" default="true"/>
   <arg name="log_file" default="iris"/>
   <arg name="headless" default="false"/>
@@ -16,6 +17,7 @@
     <arg name="model" value="$(find rotors_description)/urdf/iris_base.xacro" />
     <arg name="enable_logging" value="$(arg enable_logging)" />
     <arg name="enable_ground_truth" value="$(arg enable_ground_truth)" />
+    <arg name="enable_mavlink_interface" value="$(arg enable_mavlink_interface)" />
     <arg name="log_file" value="$(arg log_file)"/>
     <arg name="y" value="2"/>
   </include>

--- a/rotors_gazebo/launch/spawn_iris.launch
+++ b/rotors_gazebo/launch/spawn_iris.launch
@@ -9,6 +9,7 @@
   <arg name="z" default="0.08"/>
   <arg name="enable_logging" default="false"/>
   <arg name="enable_ground_truth" default="true"/>
+  <arg name="enable_mavlink_interface" default="false"/>
   <arg name="log_file" default="iris"/>
 
   <!-- send the robot XML to param server -->
@@ -16,6 +17,7 @@
     $(find xacro)/xacro.py '$(arg model)'
     enable_logging:=$(arg enable_logging)
     enable_ground_truth:=$(arg enable_ground_truth)
+    enable_mavlink_interface:=$(arg enable_mavlink_interface)
     log_file:=$(arg log_file)"
   />
   <param name="tf_prefix" type="string" value="$(arg tf_prefix)" />

--- a/rotors_gazebo_plugins/CMakeLists.txt
+++ b/rotors_gazebo_plugins/CMakeLists.txt
@@ -36,6 +36,7 @@ find_package(catkin REQUIRED COMPONENTS
 
 if (BUILD_MAVLINK_INTERFACE)
   find_package(mavros)
+  find_package(mavros_msgs)
   message(STATUS "Added mavros dependency")
 endif()
 
@@ -47,6 +48,9 @@ find_package(OpenCV REQUIRED)
 link_directories(${GAZEBO_LIBRARY_DIRS})
 include_directories(${GAZEBO_INCLUDE_DIRS})
 include_directories(${OpenCV_INCLUDE_DIRS})
+if (BUILD_MAVLINK_INTERFACE)
+  include_directories(${mavros_msgs_INCLUDE_DIRS})
+endif()
 
 catkin_package(
   INCLUDE_DIRS include ${Eigen_INCLUDE_DIRS}
@@ -92,7 +96,7 @@ add_dependencies(rotors_gazebo_multirotor_base_plugin ${catkin_EXPORTED_TARGETS}
 if (BUILD_MAVLINK_INTERFACE)
   add_library(rotors_gazebo_mavlink_interface src/gazebo_mavlink_interface.cpp)
   target_link_libraries(rotors_gazebo_mavlink_interface ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES} ${mavros_LIBRARIES})
-  add_dependencies(rotors_gazebo_mavlink_interface ${catkin_EXPORTED_TARGETS} ${mavros_EXPORTED_TARGETS})
+  add_dependencies(rotors_gazebo_mavlink_interface ${catkin_EXPORTED_TARGETS} ${mavros_EXPORTED_TARGETS} ${mavros_msgs_EXPORTED_TARGETS})
   message(STATUS "Built mavlink_interface_plugin")
 endif()
 

--- a/rotors_gazebo_plugins/include/rotors_gazebo_plugins/gazebo_mavlink_interface.h
+++ b/rotors_gazebo_plugins/include/rotors_gazebo_plugins/gazebo_mavlink_interface.h
@@ -36,7 +36,7 @@
 #include <stdio.h>
 
 #include "rotors_gazebo_plugins/common.h"
-#include <mavros/utils.h>
+#include <mavros_msgs/mavlink_convert.h>
 
 namespace gazebo {
 
@@ -93,7 +93,7 @@ class GazeboMavlinkInterface : public ModelPlugin {
   boost::thread callback_queue_thread_;
   void QueueThread();
   void CommandMotorMavros(const mav_msgs::CommandMotorSpeedPtr& input_reference_msg);
-  void MavlinkControlCallback(const mavros::Mavlink::ConstPtr &rmsg);
+  void MavlinkControlCallback(const mavros_msgs::Mavlink::ConstPtr &rmsg);
   void ImuCallback(const sensor_msgs::ImuConstPtr& imu_msg);
 
 


### PR DESCRIPTION
This includes -

-Update to keep up with updates in mavros repo. Mavlink bridging shifted from mavros to mavros_msgs
-Flag to conditionally add the mavlink_interface plugin depending on the flag set in launch file. Needed because the required plugin is also only conditionally built in makefile.
