### PR TITLE
Updated hummingbird.xacro compatibility with multirotor_base

### DIFF
--- a/rotors_description/urdf/hummingbird.xacro
+++ b/rotors_description/urdf/hummingbird.xacro
@@ -25,6 +25,8 @@ for Quadrocopter Control by Jian Wang et al.) -->
   <xacro:property name="namespace" value="hummingbird" />
   <xacro:property name="rotor_velocity_slowdown_sim" value="10" />
   <xacro:property name="mesh_file" value="hummingbird.dae" />
+  <xacro:property name="mesh_scale" value="1 1 1"/>
+  <xacro:property name="mesh_scale_prop" value=".12 .12 .12"/>
   <xacro:property name="mass" value="0.68" /> <!-- [kg] -->
   <xacro:property name="body_width" value="0.1" /> <!-- [m] -->
   <xacro:property name="body_height" value="0.12" /> <!-- [m] -->
@@ -63,7 +65,9 @@ for Quadrocopter Control by Jian Wang et al.) -->
     mass="${mass}"
     body_width="${body_width}"
     body_height="${body_height}"
-    mesh_file="${mesh_file}">
+    mesh_file="${mesh_file}"
+    mesh_scale="${mesh_scale}"
+    color="DarkGrey">
     <xacro:insert_block name="body_inertia" />
   </xacro:multirotor_base_macro>
 
@@ -83,6 +87,8 @@ for Quadrocopter Control by Jian Wang et al.) -->
     motor_number="0"
     rotor_drag_coefficient="${rotor_drag_coefficient}"
     rolling_moment_coefficient="${rolling_moment_coefficient}"
+    mesh ="propeller"
+    mesh_scale="${mesh_scale_prop}"
     color="Red">
     <origin xyz="${arm_length} 0 ${rotor_offset_top}" rpy="0 0 0" />
     <xacro:insert_block name="rotor_inertia" />
@@ -103,6 +109,8 @@ for Quadrocopter Control by Jian Wang et al.) -->
     motor_number="1"
     rotor_drag_coefficient="${rotor_drag_coefficient}"
     rolling_moment_coefficient="${rolling_moment_coefficient}"
+    mesh ="propeller"
+    mesh_scale="${mesh_scale_prop}"
     color="Blue">
     <origin xyz="0 ${arm_length} ${rotor_offset_top}" rpy="0 0 0" />
     <xacro:insert_block name="rotor_inertia" />
@@ -123,6 +131,8 @@ for Quadrocopter Control by Jian Wang et al.) -->
     motor_number="2"
     rotor_drag_coefficient="${rotor_drag_coefficient}"
     rolling_moment_coefficient="${rolling_moment_coefficient}"
+    mesh ="propeller"
+    mesh_scale="${mesh_scale_prop}"
     color="Blue">
     <origin xyz="-${arm_length} 0 ${rotor_offset_top}" rpy="0 0 0" />
     <xacro:insert_block name="rotor_inertia" />
@@ -143,6 +153,8 @@ for Quadrocopter Control by Jian Wang et al.) -->
     motor_number="3"
     rotor_drag_coefficient="${rotor_drag_coefficient}"
     rolling_moment_coefficient="${rolling_moment_coefficient}"
+    mesh ="propeller"
+    mesh_scale="${mesh_scale_prop}"
     color="Blue">
     <origin xyz="0 -${arm_length} ${rotor_offset_top}" rpy="0 0 0" />
     <xacro:insert_block name="rotor_inertia" />

--- a/rotors_gazebo_plugins/src/gazebo_odometry_plugin.cpp
+++ b/rotors_gazebo_plugins/src/gazebo_odometry_plugin.cpp
@@ -167,7 +167,7 @@ void GazeboOdometryPlugin::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf) 
                 noise_normal_angular_velocity.z * noise_normal_angular_velocity.z;
   twist_covariance = twist_covd.asDiagonal();
 
-  link_name_ = namespace_ + "/" + link_name_;
+  //link_name_ = namespace_ + "/" + link_name_;
 
   // Listen to the update event. This event is broadcast every
   // simulation iteration.


### PR DESCRIPTION
hummingbird.xacro was missing mesh_file and mesh_scale arguments for the body. Also missing mesh and mesh_scale arguments for each rotor. Added arguments to be compatible with multirotor_base.xacro
Also edited the odometry plugin to remove adding the namespace to the link name. This allows users to be more flexible with the link_name input and can add the namespace in the .xacro file when calling this plugin.
